### PR TITLE
Mark module as deprecated.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for {{ $dist->name }}: {{ $dist->version }}
 
 {{ $NEXT }}
 
+        This module is now marked as deprecated. (oalders)
+
 1.110670  2011-03-08 08:02:37 America/Chicago
         Depending on POE::Filter::HTTP::Parser 1.06 because prior versions
         constructed their URI wrong in an edge case that Plack::Test::Suite

--- a/dist.ini
+++ b/dist.ini
@@ -15,3 +15,5 @@ POE::Filter::HTTP::Parser = 1.06
 [NextRelease]
 [MetaResources]
 repository                          = git://github.com/nperez/poex-role-psgiserver.git
+
+[Deprecated]

--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,6 @@ POEx::Role::TCPServer     = 1.102740
 POE::Filter::HTTP::Parser = 1.06
 [NextRelease]
 [MetaResources]
-repository                          = git://github.com/nperez/poex-role-psgiserver.git
+repository                          = git://github.com/frodwith/poex-role-psgiserver.git
 
 [Deprecated]

--- a/lib/POEx/Role/PSGIServer.pm
+++ b/lib/POEx/Role/PSGIServer.pm
@@ -1,6 +1,6 @@
 package POEx::Role::PSGIServer;
 
-#ABSTRACT: Encapsulates core PSGI server behavior
+#ABSTRACT: (DEPRECATED) Encapsulates core PSGI server behavior
 use MooseX::Declare;
 
 =head1 SYNOPSIS
@@ -11,6 +11,8 @@ use MooseX::Declare;
     MyServer->new()->run($some_psgi_app);
 
 =head1 DESCRIPTION
+
+This module has been deprecated.
 
 POEx::Role::PSGIServer encapsulates the core L<PSGI> server behaviors into an easy to consume and extend role. It is based on previous POEx work such as POEx::Role::TCPServer which provides basic TCP socket multiplexing via POE::Wheel::SocketFactory and POE::Wheel::ReadWrite, and POEx::Role::SessionInstantiation which transforms plain Moose objects into POE sessions.
 


### PR DESCRIPTION
@neilbowers let me know that this module should be marked as deprecated, which this pull request takes care of.  If you're short on time to cut a new release, you can assign co-maint to me (OALDERS) and I can release the deprecated version for you.
